### PR TITLE
Fixed errors with the mobster accent

### DIFF
--- a/Resources/Locale/en-US/accent/mobster.ftl
+++ b/Resources/Locale/en-US/accent/mobster.ftl
@@ -1,6 +1,4 @@
-﻿﻿accent-mobster-prefix-boss-1 = Nyehh,
-
-﻿accent-mobster-prefix-minion-1 = Nyehh,
+﻿accent-mobster-prefix-1 = Nyehh,
 
 accent-mobster-suffix-boss-1 = , see?
 accent-mobster-suffix-boss-2 = , fugeddaboutit.
@@ -61,7 +59,7 @@ accent-mobster-words-17 = here
 accent-mobster-words-replace-17 = 'ere
 
 accent-mobster-words-18 = forget about it
-accent-mobster-words-replace-17 = fuhgeddaboudit
+accent-mobster-words-replace-18 = fuhgeddaboudit
 
 accent-mobster-words-19 = meeting
 accent-mobster-words-replace-19 = sitdown

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -96,4 +96,4 @@
   cost: 2
   components:
     - type: ReplacementAccent
-    - type: Mobster
+      accent: mobster


### PR DESCRIPTION
There was some funny encoding issues with the mobster localization file, so I re-saved it as UTF-8. Should be fine now.

The accent option in the character creator was set up slightly incorrectly, which caused it to fail parsing. This has also been fixed.

Note: Currently, the mobster trait is added as a replacement accent, so it's won't include random additions like "capiche" and "fugeddaboutit" at the end of the sentence.