### PR TITLE
Drag damage tweaks

### DIFF
--- a/Content.Server/Damage/Systems/DamageOnDraggingCritSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnDraggingCritSystem.cs
@@ -9,6 +9,8 @@ using Content.Shared.Damage;
 using Content.Server.Damage.Components;
 using Content.Shared.Gravity;
 using Content.Shared.Effects;
+using Content.Shared.Inventory;
+using Content.Shared.Tag;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 
@@ -23,6 +25,8 @@ public sealed class DamageOnDraggingCritSystem : EntitySystem
     [Dependency] private readonly SharedGravitySystem _gravity = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
     //[Dependency] private readonly SharedAudioSystem _audio = default!;
 
     private EntityQuery<PullableComponent> _pullableQuery;
@@ -96,6 +100,11 @@ public sealed class DamageOnDraggingCritSystem : EntitySystem
 
         // Check that we are not weightless
         if(_gravity.IsWeightless(uid))
+            return;
+        
+        // Check that we're not wearing a hardsuit
+        // We don't want to make salvage's job harder
+        if(_inventory.TryGetSlotEntity(uid, "outerClothing", out var suit) && _tag.HasTag(suit.Value, "Hardsuit"))
             return;
 
         var adjustedThreshold = comp.DistanceThreshold * comp.Interval.TotalSeconds;

--- a/Content.Server/Damage/Systems/DamageOnDraggingCritSystem.cs
+++ b/Content.Server/Damage/Systems/DamageOnDraggingCritSystem.cs
@@ -8,6 +8,9 @@ using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Damage;
 using Content.Server.Damage.Components;
 using Content.Shared.Gravity;
+using Content.Shared.Effects;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
 
 namespace Content.Server.Damage.Systems;
 
@@ -19,6 +22,8 @@ public sealed class DamageOnDraggingCritSystem : EntitySystem
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly SharedGravitySystem _gravity = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly SharedColorFlashEffectSystem _color = default!;
+    //[Dependency] private readonly SharedAudioSystem _audio = default!;
 
     private EntityQuery<PullableComponent> _pullableQuery;
     private EntityQuery<MobThresholdsComponent> _thresholdsQuery;
@@ -97,6 +102,10 @@ public sealed class DamageOnDraggingCritSystem : EntitySystem
         //Log.Info($"Distance dragged: {comp.DistanceDragged} / {adjustedThreshold}");
 
         if(comp.DistanceDragged >= adjustedThreshold)
+        {
             _damageable.TryChangeDamage(uid, comp.Damage * (_gameTiming.CurTime - comp.LastInterval).TotalSeconds, origin: pullable.Puller);
+            _color.RaiseEffect(Color.Red, new List<EntityUid>() { uid }, Filter.Pvs(uid, entityManager: EntityManager));
+            //_audio.PlayPvs(comp.DragSound, uid);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR adds some tweaks to drag damage to better communicate what is happening, and to improve the balance.

Bodies that are receiving drag damage will now flash red. Hardsuits now protect from drag damage.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The rollout of drag damage wasn't well communicated, and most people in the Discord thread were surprised to hear it was already merged. Someone suggested that dragging damage be given a visual/audio cue, to let people know that they're damaging bodies. I added a red damage flash when drag damage is applied. I couldn't find a good sound in the files, so there's no audio cue yet. One can be easily added later on.

It was noted in the Discord thread that drag damage unintentionally punishes Salvage, who have limited resources in the field of a mission. To remedy this, hardsuits now protect from drag damage.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

The `DamageOnDraggingCritSystem` system calls `SharedColorFlashEffectSystem.RaiseEffect` on the dragged entity every `Interval` when drag damage is being received. The system also checks if the `outerClothing` slot of the mob's inventory has clothing with the tag `Hardsuit`.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/user-attachments/assets/6e06faf2-66ef-43ea-97dc-776333e83e44

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: TGRCdev
- tweak: Bodies receiving drag damage will now flash red.
- tweak: Hardsuits now prevent drag damage.
