### PR TITLE
Spy Vs Spy Additional Modes and TC balances, Traitor/Sleeper Agent objective fixes

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -158,6 +158,21 @@
   - type: TraitorRule
   # TODO: codewords in yml
   # TODO: uplink in yml
+  - type: AntagRandomObjectives
+    sets:
+    - groups: TraitorObjectiveGroups
+    maxDifficulty: 5
+  - type: AntagSelection
+    agentName: traitor-round-end-agent-name
+
+- type: entity
+  abstract: true
+  parent: BaseGameRule
+  id: BaseTraitorRuleNoRandomObjectives
+  components:
+  - type: TraitorRule
+  # TODO: codewords in yml
+  # TODO: uplink in yml
   - type: AntagSelection
     agentName: traitor-round-end-agent-name
 
@@ -170,10 +185,6 @@
     delay:
       min: 240
       max: 420
-  - type: AntagRandomObjectives
-    sets:
-    - groups: TraitorObjectiveGroups
-    maxDifficulty: 5
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]
@@ -188,9 +199,69 @@
         prototype: Traitor
 
 - type: entity
-  parent: BaseTraitorRule
+  parent: BaseTraitorRuleNoRandomObjectives
+  id: SpyVsSpyDefaultTC
+  components:
+  - type: GameRule
+    minPlayers: 15
+    delay:
+      min: 240
+      max: 42
+  - type: AntagObjectives
+    objectives:
+    - KillRandomTraitorSvSObjective
+    - RandomTraitorAliveSvSObjective
+    - EscapeShuttleObjective
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ Traitor ]
+      max: 100
+      playerRatio: 1
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      forceAllPossible: true
+      mindComponents:
+      - type: TraitorRole
+        prototype: Traitor
+
+- type: entity
+  parent: BaseTraitorRuleNoRandomObjectives
+  id: SpyVsSpy5TC
+  components:
+  - type: TraitorRule
+    startingBalance: 5
+  - type: GameRule
+    minPlayers: 15
+    delay:
+      min: 240
+      max: 420
+  - type: AntagObjectives
+    objectives:
+    - KillRandomTraitorSvSObjective
+    - RandomTraitorAliveSvSObjective
+    - EscapeShuttleObjective
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ Traitor ]
+      max: 100
+      playerRatio: 1
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      forceAllPossible: true
+      mindComponents:
+      - type: TraitorRole
+        prototype: Traitor
+
+- type: entity
+  parent: BaseTraitorRuleNoRandomObjectives
   id: SpyVsSpy
   components:
+  - type: TraitorRule
+    startingBalance: 0
   - type: GameRule
     minPlayers: 15
     delay:

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -116,6 +116,28 @@
     - BasicRoundstartVariation
 
 - type: gamePreset
+  id: SpyVsSpyDefaultTC
+  name: spy-vs-spy-title
+  description: spy-vs-spy-description
+  showInVote: false
+  rules:
+    - SpyVsSpyDefaultTC
+    - BasicStationEventScheduler
+    - GameRuleMeteorScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
+  id: SpyVsSpy5TC
+  name: spy-vs-spy-title
+  description: spy-vs-spy-description
+  showInVote: false
+  rules:
+    - SpyVsSpy5TC
+    - BasicStationEventScheduler
+    - GameRuleMeteorScheduler
+    - BasicRoundstartVariation
+
+- type: gamePreset
   id: SpyVsSpy
   alias:
     - svs


### PR DESCRIPTION
Added seperate base traitor parent with no random objectives and added random objectives back to the original parent instead of assigning them in the subroles. This seems to have fixed the issues with traitors not getting objectives. Also added 3 seperate versions of SVS for testing, one with 0 TC starting, one with 5TC starting, and one with 20TC (default) starting.

:cl:
- add: Base Spy Vs Spy now starts everyone with 0 TC. Also added variants with 5 starting TC, and default (20) starting TC to test with. 
- fix: Traitors and Sleeper Agents should no longer have blank objectives.
