### PR TITLE
ToggleReady command now ignores duplicate inputs

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -175,6 +175,11 @@ namespace Content.Server.GameTicking
             }
 
             var status = ready ? PlayerGameStatus.ReadyToPlay : PlayerGameStatus.NotReadyToPlay;
+            if (_playerGameStatuses[player.UserId] == status)
+            {
+                return;
+            }
+
             _playerGameStatuses[player.UserId] = ready ? PlayerGameStatus.ReadyToPlay : PlayerGameStatus.NotReadyToPlay;
             RaiseNetworkEvent(GetStatusMsg(player), player.Channel);
             RaiseLocalEvent(new PlayerToggleReadyEvent(player));


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Stops the `toggleready true/false` command (used by the ready button) from readying or un-readying a player who is already ready or not ready.

This fixes a few oversights causing the ready manifest to become inaccurate when someone double-clicks or mashes the ready button, manually enters the command multiple times in the console, or opens the customization menu while unreadied.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
The `ToggleReady` method in `GameTicker.Lobby.cs` now returns when attempting to change a player's ready status to what it already is. 



**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Fixed certain inaccuracies in the ready manifest display