### PR TITLE
Fixed YAML errors

### DIFF
--- a/Resources/Audio/Animals/attributions.yml
+++ b/Resources/Audio/Animals/attributions.yml
@@ -157,5 +157,7 @@
   license: "CC-BY-NC-SA-4.0"
   source: "https://github.com/space-wizards/space-station-14/pull/27578"
 
-- files: spooky_horse.ogg
+- files: ["spooky_horse.ogg"]
+  license: "CC-BY-SA-3.0"
+  copyright: "Recorded by user Faithhollow1 on Freesound.org"
   source: "https://freesound.org/people/Faithhollow1/sounds/186577/"

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -157,13 +157,13 @@
             Quantity: 10
           - ReagentId: Tricordrazine
             Quantity: 10
-    food:
-        maxVol: 40
-        reagents:
-          - ReagentId: Nicotine
-            Quantity: 10
-          - ReagentId: Tricordrazine
-            Quantity: 10
+      food:
+          maxVol: 40
+          reagents:
+            - ReagentId: Nicotine
+              Quantity: 10
+            - ReagentId: Tricordrazine
+              Quantity: 10
 
 - type: entity
   id: CigaretteDylovene

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -206,7 +206,7 @@
     minPlayers: 15
     delay:
       min: 240
-      max: 42
+      max: 420
   - type: AntagObjectives
     objectives:
     - KillRandomTraitorSvSObjective

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -1964,7 +1964,7 @@
           reagent: Radium
           amount: 0.05
         - !type:PopupMessage
-          Conditions:
+          conditions:
             - !type:ReagentThreshold
               reagent: UAP
               min: 1
@@ -1974,7 +1974,7 @@
           messages: [ "uap-effect-n1"]
           probability: 0.1
         - !type:PopupMessage
-          Conditions:
+          conditions:
             - !type:ReagentThreshold
               reagent: UAP
               min: 10
@@ -1984,7 +1984,7 @@
           messages: [ "uap-effect-n2" ]
           probability: 0.1
         - !type:PopupMessage
-          Conditions:
+          conditions:
             - !type:ReagentThreshold
               reagent: UAP
               min: 20


### PR DESCRIPTION
Fixing various issues with the YAML resource files

- `spooky_horse.ogg` was missing a `copyright` and `license` key, which caused errors. I found and applied the proper licensing.
- A type of cigarette had incorrect indentation, causing the `food` section to be incorrectly parsed.
- The round start event for Spy vs Spy had a max delay smaller than its min delay, most likely due to a zero left out erroneously.

These errors were emailed to me by Github Actions, surprisingly. I didn't realize I had turned it on for my branch, but I'm not gonna complain.