### PR TITLE
Fix for issue where codeword highlighting would sometimes make people deaf

### DIFF
--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -241,11 +241,12 @@ public abstract class SharedChatSystem : EntitySystem
 
     /// <summary>
     /// Injects a tag around all found instances of a specific string in a ChatMessage.
+    /// Excludes strings inside other tags and brackets.
     /// </summary>
     public static string InjectTagAroundString(ChatMessage message, string targetString, string tag, string? tagParameter)
     {
         var rawmsg = message.WrappedMessage;
-        rawmsg = Regex.Replace(rawmsg, "(?i)(" + targetString + ")(?-i)", $"[{tag}={tagParameter}]$1[/{tag}]");
+        rawmsg = Regex.Replace(rawmsg, "(?i)(" + targetString + ")(?-i)(?![^[]*])", $"[{tag}={tagParameter}]$1[/{tag}]");
         return rawmsg;
     }
 

--- a/Resources/Prototypes/Datasets/adjectives.yml
+++ b/Resources/Prototypes/Datasets/adjectives.yml
@@ -314,7 +314,6 @@
   - slow
   - swift
   - young
-  - Taste/Touch
   - bitter
   - delicious
   - fresh

--- a/Resources/Prototypes/Datasets/verbs.yml
+++ b/Resources/Prototypes/Datasets/verbs.yml
@@ -97,7 +97,9 @@
   - coach
   - coil
   - collect
+  - colour
   - comb
+  - command
   - communicate
   - compare
   - compete
@@ -542,6 +544,7 @@
   - suffer
   - suggest
   - suit
+  - supply
   - support
   - suppose
   - surprise

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -103,7 +103,7 @@
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
   id: ClothingOuterArmorRaid
   name: syndicate raid suit
-  description: A somewhat flexible and well-armored suit with a powerful shoulder mounted flashlight manufactured in the Gorlex Marauder's iconic blood-red color scheme, it does not protect it's wearer from space.
+  description: A somewhat flexible and well-armored suit with a powerful shoulder mounted flashlight manufactured in the Gorlex Marauder's iconic blood-red color scheme, it does not protect its wearer from space.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Armor/syndie-raid.rsi

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/shuttle.yml
@@ -63,6 +63,8 @@
       path: /Audio/Machines/airlock_deny.ogg
   - type: Airtight
     noAirWhenFullyAirBlocked: false
+    airBlockedDirection:
+      - South
   - type: Tag
     tags:
       - ForceNoFixRotations


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes and your own changes.
Make separate pull requests for separate changes. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Ported in a bugfix, merge some upstream stuff. I will refrain from doing this in the future. It's good practice to have separate merge PRs...

:cl: 

- fix: Codewords should no longer make people locally deaf.