### PR TITLE
YAML fixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/graypipe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/graypipe.yml
@@ -4,9 +4,6 @@
   id: PVC
   description: Percision Velocity Channeler.
   components:
-  - type: Tag
-    tags:
-    - PVC
   - type: Sprite
     sprite: Objects/Weapons/Melee/pvc.rsi
   - type: MeleeWeapon

--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -55,10 +55,6 @@
 
 - type: loadout
   id: CigPackNewport
-  equipment: CigPackNewport
-
-- type: startingGear
-  id: CigPackNewport
   storage:
     back:
     - CigPackNewport
@@ -149,10 +145,6 @@
     - ClothingNeckGoldAutismPin
 
 - type: loadout
-  id: PersonalAI
-  equipment: PersonalAI
-
-- type: startingGear
   id: PersonalAI
   storage:
     back:


### PR DESCRIPTION
Fixes the Newports and pAI trinkets. Also removes the "PVC" tag from the PVC pipe because it was unused, and was never declared in `tags.yml`, causing errors.