### PR TITLE
Fixed IP bans preventing non-banned players from connecting to SQLite-backed servers

### DIFF
--- a/Content.Server/IP/IPAddressExt.cs
+++ b/Content.Server/IP/IPAddressExt.cs
@@ -61,6 +61,12 @@ namespace Content.Server.IP
 
         public static bool IsInSubnet(this System.Net.IPAddress address, System.Net.IPAddress maskAddress, int maskLength)
         {
+            if (maskAddress.AddressFamily != address.AddressFamily)
+            {
+                // We got something like an IPV4-Address for an IPv6-Mask. This is not valid.
+                return false;
+            }
+
             if (maskAddress.AddressFamily == AddressFamily.InterNetwork)
             {
                 // Convert the mask address to an unsigned integer.
@@ -89,7 +95,7 @@ namespace Content.Server.IP
 
                 if (maskAddressBits.Length != ipAddressBits.Length)
                 {
-                    throw new ArgumentException("Length of IP Address and Subnet Mask do not match.");
+                    return false;
                 }
 
                 // Compare the prefix bits.

--- a/Content.Tests/Server/Utility/IPAddressExtTest.cs
+++ b/Content.Tests/Server/Utility/IPAddressExtTest.cs
@@ -26,6 +26,7 @@ namespace Content.Tests.Server.Utility
         [TestCase("10.128.240.50/30", "10.128.240.52")]
         [TestCase("10.128.240.50/30", "10.128.239.50")]
         [TestCase("10.128.240.50/30", "10.127.240.51")]
+        [TestCase("10.128.240.50/30", "2001:0DB8:ABCD:0012:0000:0000:0000:0000")]
         public void IpV4SubnetMaskDoesNotMatchInvalidIpAddress(string netMask, string ipAddress)
         {
             var ipAddressObj = IPAddress.Parse(ipAddress);
@@ -51,6 +52,7 @@ namespace Content.Tests.Server.Utility
         [TestCase("2001:db8:abcd:0012::0/64", "2001:0DB8:ABCD:0013:0001:0000:0000:0000")]
         [TestCase("2001:db8:abcd:0012::0/64", "2001:0DB8:ABCD:0011:FFFF:FFFF:FFFF:FFF0")]
         [TestCase("2001:db8:abcd:0012::0/128", "2001:0DB8:ABCD:0012:0000:0000:0000:0001")]
+        [TestCase("2001:db8:abcd:0012::0/128", "10.128.239.50")]
         // ReSharper restore StringLiteralTypo
         public void IpV6SubnetMaskDoesNotMatchInvalidIpAddress(string netMask, string ipAddress)
         {


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes and your own changes.
Make separate pull requests for separate changes. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

This PR fixes a long-standing bug in the SQLite code that throws an error for newly connecting players if an IP ban has been given to a player.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

When an IP ban is given, their IP is stored in the database in the address format the player was connected by. So, if a player was connected via IPv6, their ban would have their IPv6 address.

When a new player connects to a server running a SQLite database backend, the database checks every ban IP to see if it matches the new player's IP with the method `IsInSubnet`. For some reason, this method throws an error if the subnet and the address are in different address formats, instead of simply returning `false`. So, if a player was IP banned with an IPv6 address, this would cause all players connecting via IPv4 to be dropped due to an error, and vice-versa.

I simply added a check to `IsInSubnet` that returns `false` if the address and the mask are in different formats.

I believe that this issue did not appear in larger servers like Wizards Den because they run using the Postgres database backend, which handles ban checking differently.

## Media
<!--
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!--
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!-- Impstation note: we have our own changelog now, so please DO use this section! -->
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: TGRCDev
- fix: IP bans no longer prevent non-banned players from connecting
