### PR TITLE
Fixed monkeys not being blinded when welding without a welding mask

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1196,6 +1196,7 @@
     speciesId: monkey
   - type: Deathgasp
     prototype: MonkeyDeathgasp
+  - type: Blindable
   - type: Cuffable
   - type: RotationVisuals
     defaultRotation: 90


### PR DESCRIPTION
Just added the `Blindable` component to the `MobBaseAncestor` mob that all monkeys inherit from.