### PR TITLE
Added Vials to the techfab

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -296,6 +296,7 @@
       - Implanter
       - PillCanister
       - ChemistryEmptyBottle01
+      - BaseChemistryEmptyVial
       - AdvMopItem
       - WeaponSprayNozzle
       - ClothingBackpackWaterTank
@@ -909,6 +910,7 @@
       - PillCanister
       - BodyBag
       - ChemistryEmptyBottle01
+      - BaseChemistryEmptyVial
       - RollerBedSpawnFolded
       - CheapRollerBedSpawnFolded
       - EmergencyRollerBedSpawnFolded

--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -80,6 +80,13 @@
     Glass: 50
 
 - type: latheRecipe
+  id: BaseChemistryEmptyVial
+  result: BaseChemistryEmptyVial
+  completetime: 2
+  materials:
+    Glass: 50
+
+- type: latheRecipe
   id: Vape
   icon:
     sprite: Objects/Consumable/Smokeables/Vapes/vape-standard.rsi


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes and your own changes.
Make separate pull requests for separate changes. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added vials to the medical techfab. 
They cost 0.5 glass to make same as bottles since thats the cost of bottles and they have the same capacity as bottles.
I have no idea why this wasnt in the game already.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It should have been in the game for a while honestly. 
Chem currently just starts with 6 vials and theres no way to acquire more.

**Changelog**
<!-- Impstation note: we have our own changelog now, so please DO use this section! -->
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.
:cl:
- add: Vial recipe to the medical techfab
-->
