### PR TITLE
new drinks + bartender unlock tweak

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/consumable/drink/alcohol.ftl
+++ b/Resources/Locale/en-US/reagents/meta/consumable/drink/alcohol.ftl
@@ -285,3 +285,24 @@ reagent-desc-uap = An unidentified alcoholic product...
 
 reagent-name-theehorsepussy = The Horsepussy
 reagent-desc-theehorsepussy = They are going this drink after me when i die
+
+reagent-name-lovetap = Love tap
+reagent-desc-lovetap = Straight Root Beer, with a love tap of Rum.
+
+reagent-name-calimotxo = Calimotxo
+reagent-desc-calimotxo = A classy, 50/50 mix of Wine and Cola.
+
+reagent-name-reaganomics = Reaganomics
+reagent-desc-reaganomics = Why would we ever want anything else?
+
+reagent-name-gatorwine = Gatorwine
+reagent-desc-gatorwine = No Reptillians were harmed in the making of this drink.
+
+reagent-name-rotgut = Rotgut
+reagent-desc-rotgut = A perfect excuse to check up with that cute girl in the emergency ward.
+
+reagent-name-white-gilgamesh = White Gilgamesh
+reagent-desc-white-gilgamesh = it isn't good
+
+reagent-name-bumwine = Bum Wine
+reagent-desc-bumwine = For the economical drinker. You know drinks are free though, right?

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
@@ -6,12 +6,12 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobBartender
-      time: 180000 #50 hrs
+      time: 36000 #10 hrs
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:DepartmentTimeRequirement
       department: Medical
-      time: 72000 # 20 hrs
+      time: 36000 # 10 hrs
 # Head
 - type: loadout
   id: BartenderHead

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -2019,9 +2019,9 @@
 
 - type: reagent
   id: TheHorsepussy
-  name: reagent-name-thehorsepussy
+  name: reagent-name-theehorsepussy
   parent: BaseAlcohol
-  desc: reagent-desc-thehorsepussy
+  desc: reagent-desc-theehorsepussy
   physicalDesc: reagent-physical-desc-evil
   flavor: horsepussy
   color: "#7BD18C"
@@ -2055,5 +2055,140 @@
         - !type:MobStateCondition
           mobstate: Alive
 
+- type: reagent
+  id: Calimotxo
+  name: reagent-name-calimotxo
+  parent: BaseAlcohol
+  desc: reagent-desc-calimotxo
+  physicalDesc: reagent-physical-desc-bubbly
+  flavor: cola
+  color: "#663100"
+  recognizable: true
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/martiniglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: false
+  fizziness: 0.8
 
+- type: reagent
+  id: LoveTap
+  name: reagent-name-lovetap
+  parent: BaseAlcohol
+  desc: reagent-desc-lovetap
+  physicalDesc: reagent-physical-desc-bubbly
+  flavor: rootbeersoda
+  color: "#381c07"
+  recognizable: true
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/rootbeerglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: false
+  fizziness: 0.8
 
+- type: reagent
+  id: Reaganomics
+  name: reagent-name-reaganomics
+  parent: BaseSoda
+  desc: reagent-desc-reaganomics
+  physicalDesc: reagent-physical-desc-evil
+  flavor: energydrink
+  color: "#ff6500"
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:GenericStatusEffect
+        key: Drowsiness
+        time: 5
+        type: Add
+    Narcotic:
+      effects:
+      - !type:GenericStatusEffect
+        key: SeeingRainbows
+        component: SeeingRainbows
+        type: Add
+        time: 5
+        refresh: false
+    Medicine:
+      effects:
+      - !type:HealthChange
+        probability: 0.25
+        damage:
+          types:
+            Blunt: 20
+        conditions:
+        - !type:ReagentThreshold
+          min: 20
+        - !type:MobStateCondition
+          mobstate: Alive
+  fizziness: 0.2
+  
+- type: reagent
+  id: GatorWine
+  name: reagent-name-gatorwine
+  parent: BaseAlcohol
+  desc: reagent-desc-gatorwine
+  physicalDesc: reagent-physical-desc-bubbly
+  flavor: sweet
+  color: "#ffee3e"
+  recognizable: true
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/martiniglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: false
+  fizziness: 0.8
+  
+- type: reagent
+  id: Rotgut
+  name: reagent-name-rotgut
+  parent: BaseSoda
+  desc: reagent-desc-rotgut
+  physicalDesc: reagent-physical-desc-murky
+  flavor: flavor-base-horrible
+  color: "#8a8048"
+  metabolisms:
+    Drink:
+      effects:
+      - !type:SatiateThirst
+        factor: 2
+      - !type:GenericStatusEffect
+        key: Drowsiness
+        time: 5
+        type: Add
+    Medicine:
+      effects:
+      - !type:HealthChange
+        probability: 0.25
+        damage:
+          types:
+            Poison: 10
+        conditions:
+        - !type:ReagentThreshold
+          min: 20
+        - !type:MobStateCondition
+          mobstate: Alive
+  fizziness: 0
+  
+- type: reagent
+  id: BumWine
+  name: reagent-name-bumwine
+  parent: BaseAlcohol
+  desc: reagent-desc-bumwine
+  physicalDesc: reagent-physical-desc-syrupy
+  flavor: sweet
+  color: "#e74f4f"
+  recognizable: true
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/wineglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: false
+  fizziness: 0.9

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -1215,3 +1215,83 @@
     TheHorsepussy: 3
   sound:
     path: /Audio/Animals/spooky_horse.ogg
+
+- type: reaction
+  id: Calimotxo
+  requiredMixerCategories:
+    - Stir
+  reactants:
+    Wine:
+      amount: 1
+    Cola:
+      amount: 1
+  products:
+    Calimotxo: 2
+    
+- type: reaction
+  id: LoveTap
+  requiredMixerCategories:
+    - Stir
+  reactants:
+    Rum:
+      amount: 1
+    RootBeer:
+      amount: 9
+  products:
+    LoveTap: 10
+    
+- type: reaction
+  id: Raeganomics
+  requiredMixerCategories:
+    - Shake
+  reactants:
+    THC:
+      amount: 1
+    Nicotine:
+      amount: 1
+    Lemonade:
+      amount: 1
+    Vodka:
+      amount: 2
+  products:
+    Reaganomics: 5
+    
+- type: reaction
+  id: GatorWine
+  requiredMixerCategories:
+    - Stir
+  reactants:
+    LemonAsterade:
+      amount: 1
+    Wine:
+      amount: 1
+  products:
+    GatorWine: 2
+    
+- type: reaction
+  id: Rotgut
+  requiredMixerCategories:
+    - Shake
+  reactants:
+    Water:
+      amount: 1
+    Sugar:
+      amount: 4
+    Nicotine:
+      amount: 5
+  products:
+    Rotgut: 10
+    
+- type: reaction
+  id: BumWine
+  requiredMixerCategories:
+    - Stir
+  reactants:
+    Wine:
+      amount: 2
+    Sugar:
+      amount: 1
+    Water:
+      amount: 3
+  products:
+    BumWine: 5


### PR DESCRIPTION
<!-- Impstation note: there's no need to read all the official contributing guidelines,
but please DON'T combine upstream changes and your own changes.
Make separate pull requests for separate changes. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added six new drinks: Rotgut, Bum wine, Love tap, Calimotxo, Gatorwine and Reaganomics.
Fixed the names and desc for White Gilgamesh and The Horsepussy.
Drastically reduced the requirement time for the bartender Chemmaster 4k unlockable.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
The requirement was a bit excessive, considering its just a toy and not some powerful unlock or veteran cosmetic.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->


## Requirements
<!--
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!-- Impstation note: we have our own changelog now, so please DO use this section! -->
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Six new drinks! Rotgut, Bum wine, Love tap, Calimotxo, Gatorwine and Reaganomics.
- tweak: Reduced the unlock requirements for the bartender flatpack unlock.
- fix: Fixed the names and descriptions for The Horsepussy and White gilgamesh.
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog.

-->
