### PR TITLE
turn off ai-incompatible maps for now

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -1,19 +1,19 @@
 - type: gameMapPool
   id: DefaultMapPool
   maps:
-  - Atlas
+  # - Atlas
   - Bagel
-  - Boat
+  # - Boat
   - Box
   - Cog
-  - Cluster
+  # - Cluster
   - Core
   - Fland
   - Marathon
   - Meta
   - Oasis
   - Omega
-  - Saltern
+  # - Saltern
   - Packed
   - Reach
-  - Train
+  # - Train


### PR DESCRIPTION
DO NOT MERGE until we decide it's time to start testing AI.

This turns off every map that isn't currently AI-compatible. We don't know if running an AI-less game is safe or not yet.