### PR TITLE
ftl and cargo tech dupe pda fix

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -225,10 +225,10 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
 
                 // The actual position in the UI. We offset the matrix position to render it off by half its width
                 // plus by the offset.
-                var uiPosition = ScalePosition(gridCentre)- new Vector2(labelDimensions.X / 2f, -yOffset);
+                var uiPosition = ScalePosition(gridCentre) - new Vector2(labelDimensions.X / 2f, -yOffset);
 
                 // Look this is uggo so feel free to cleanup. We just need to clamp the UI position to within the viewport.
-                uiPosition = new Vector2(Math.Clamp(uiPosition.X, 0f, PixelWidth - labelDimensions.X ),
+                uiPosition = new Vector2(Math.Clamp(uiPosition.X, 0f, PixelWidth - labelDimensions.X),
                     Math.Clamp(uiPosition.Y, 0f, PixelHeight - labelDimensions.Y));
 
                 handle.DrawString(Font, uiPosition, labelText, color);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -118,7 +118,7 @@ public sealed partial class ShuttleSystem
                 continue;
             }
 
-            TryAddFTLDestination(gridXform.MapID, true, out _);
+            TryAddFTLDestination(gridXform.MapID, true, false, false, out _);
         }
     }
 

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -15,7 +15,6 @@
 - type: startingGear
   id: CargoTechGear
   equipment:
-    id: CargoPDA
     ears: ClothingHeadsetCargo
     pocket1: AppraisalTool
   #storage:


### PR DESCRIPTION
## About the PR
fixes ftl and the duplicate cargo tech pda introduced by the senior cargo tech pr (pr). ftl fix pulled from https://github.com/space-wizards/space-station-14/pull/31569

## Why / Balance
shit broke

## Technical details
every ftl destination wanted a disk to be warped to. cargo techs did not have their regular pda removed from their loadout, causing them to spawn with both their original one and their new loadout-based one

:cl:
- fix: Fixed off-station FTL.
- fix: Cargo techs now have only one PDA.
