### PR TITLE
fix dupe cargo tech pda

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -15,7 +15,6 @@
 - type: startingGear
   id: CargoTechGear
   equipment:
-    id: CargoPDA
     ears: ClothingHeadsetCargo
     pocket1: AppraisalTool
   #storage:


### PR DESCRIPTION
## About the PR
cargo techs used to spawn with an additional pda since the roundstart loadout wasnt changed. now its fixed!

**Changelog**
:cl:
- fix: Cargo techs now spawn with only one PDA.
