### PR TITLE
salvage neck loadout fix

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -645,6 +645,7 @@
 - type: loadoutGroup
   id: SalvageSpecialistNeck
   name: loadout-group-salvage-specialist-neck
+  minLimit: 0
   loadouts:
   - MinerCloak
   - SaMantle


### PR DESCRIPTION
## About the PR
salvage specialists were forced to have a piece of neckwear (min 1, max 1). now the minimum is 0

:cl:
- fix: Salvage specialists are no longer required to wear a mantle or scarf.
