### PR TITLE
beenade nerf

### DIFF
--- a/Content.Server/Explosion/Components/SpawnOnTriggerComponent.cs
+++ b/Content.Server/Explosion/Components/SpawnOnTriggerComponent.cs
@@ -9,4 +9,7 @@ public sealed partial class SpawnOnTriggerComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("proto", required: true, customTypeSerializer:typeof(PrototypeIdSerializer<EntityPrototype>))]
     public string Proto = string.Empty;
+
+    [DataField("amount")]
+    public int Amount = 1;
 }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -164,7 +164,7 @@ namespace Content.Server.Explosion.EntitySystems
             if (!coords.IsValid(EntityManager))
                 return;
 
-            Spawn(component.Proto, coords);
+            for (var i = 0; i < component.Amount; i++) { Spawn(component.Proto, coords); }
         }
 
         private void HandleExplodeTrigger(EntityUid uid, ExplodeOnTriggerComponent component, TriggerEvent args)

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -416,13 +416,11 @@
   - type: Sprite
     sprite: Objects/Weapons/Grenades/beenade.rsi
   - type: SmokeOnTrigger
-    duration: 15
-    spreadAmount: 25
-    smokePrototype: Foam
-    solution:
-      reagents:
-      - ReagentId: BuzzochloricBees
-        Quantity: 30
+    duration: 5
+    spreadAmount: 30
+  - type: SpawnOnTrigger
+    proto: MobAngryBee
+    amount: 6
 
 - type: entity
   parent: SmokeGrenade

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -52,7 +52,7 @@
   color: "#FFD35D"
   tileReactions:
   - !type:CreateEntityTileReaction
-    entity: MobAngryBee
+    entity: MobBee
     usage: 2
     maxOnTile: 2
     randomOffsetMax: 0.3


### PR DESCRIPTION
## About the PR
beenades are overdue a nerf. i think everybody is sick of seeing 3 of these motherfuckers thrown down in evac. they'll still probably need a nerf after this but it should be more in line.
this also adds functionality for grenades to spawn multiple mobs, effects, or whatever else

## Why / Balance
fuck beenades

:cl:
- tweak: Nerfed beenades to only spawn 6 angry bees.
-->
