### PR TITLE
Added mini jetpacks to salv starting loadout

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -3,6 +3,7 @@
   table: !type:AllSelector
     children:
     - id: OxygenTankFilled
+    - id: JetpackMiniFilled
     - id: ClothingShoesBootsMag
     - id: ClothingOuterHardsuitSpatio
     - id: ClothingMaskGasExplorer

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -187,13 +187,14 @@
   components:
     - type: Item
       sprite: Objects/Tanks/Jetpacks/mini.rsi
+      size: Normal
     - type: Sprite
       sprite: Objects/Tanks/Jetpacks/mini.rsi
     - type: Clothing
       sprite: Objects/Tanks/Jetpacks/mini.rsi
       slots:
         - Back
-        - suitStorage
+        - SuitStorage
         - Belt
     - type: GasTank
       outputPressure: 42.6
@@ -265,7 +266,7 @@
     sprite: Objects/Tanks/Jetpacks/void.rsi
     slots:
       - Back
-      - suitStorage
+      - SuitStorage
       - Belt
 
 # Filled void


### PR DESCRIPTION
Salvage needs not fire extinguishers imo. 
:cl:
- add: Added mini jetpacks to salvage suit storage and lockers. 
- tweak: Made mini jetpacks a normal size item instead of huge