### PR TITLE
added pride cloaks in the uniform printer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1122,6 +1122,16 @@
       - CarpetPurple
       - CarpetCyan
       - CarpetWhite
+      # Pride Cloaks
+      - ClothingNeckCloakTrans
+      - ClothingNeckCloakAce
+      - ClothingNeckCloakAro
+      - ClothingNeckCloakBi
+      - ClothingNeckCloakIntersex
+      - ClothingNeckCloakLesbian
+      - ClothingNeckCloakGay
+      - ClothingNeckCloakEnby
+      - ClothingNeckCloakPan
   - type: EmagLatheRecipes
     emagStaticRecipes:
       - ClothingHeadHatCentcomcap

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -1261,3 +1261,66 @@
   completetime: 1
   materials:
     Cloth: 100
+
+- type: latheRecipe
+  id: ClothingNeckCloakTrans
+  result: ClothingNeckCloakTrans
+  completetime: 3.2
+  materials:
+    Durathread: 200
+
+- type: latheRecipe
+  id: ClothingNeckCloakAce
+  result: ClothingNeckCloakAce
+  completetime: 3.2
+  materials:
+    Durathread: 200
+
+- type: latheRecipe
+  id: ClothingNeckCloakAro
+  result: ClothingNeckCloakAro
+  completetime: 3.2
+  materials:
+    Durathread: 200
+
+- type: latheRecipe
+  id: ClothingNeckCloakBi
+  result: ClothingNeckCloakBi
+  completetime: 3.2
+  materials:
+    Durathread: 200
+
+- type: latheRecipe
+  id: ClothingNeckCloakIntersex
+  result: ClothingNeckCloakIntersex
+  completetime: 3.2
+  materials:
+    Durathread: 200
+
+- type: latheRecipe
+  id: ClothingNeckCloakLesbian
+  result: ClothingNeckCloakLesbian
+  completetime: 3.2
+  materials:
+    Durathread: 200
+
+- type: latheRecipe
+  id: ClothingNeckCloakGay
+  result: ClothingNeckCloakGay
+  completetime: 3.2
+  materials:
+    Durathread: 200
+
+- type: latheRecipe
+  id: ClothingNeckCloakEnby
+  result: ClothingNeckCloakEnby
+  completetime: 3.2
+  materials:
+    Durathread: 200
+
+- type: latheRecipe
+  id: ClothingNeckCloakPan
+  result: ClothingNeckCloakPan
+  completetime: 3.2
+  materials:
+    Durathread: 200


### PR DESCRIPTION
## About the PR
the hop's uniform printer can now print pride cloaks

## Why / Balance
gay

:cl:
- add: The HoP can now print pride cloaks.
