### PR TITLE
Carrots and Occuline

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -467,8 +467,6 @@
           Quantity: 5
         - ReagentId: Vitamin
           Quantity: 4
-        - ReagentId: Oculine
-          Quantity: 3
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/carrot.rsi
   - type: Produce
@@ -478,8 +476,6 @@
       reagents:
       - ReagentId: JuiceCarrot
         Quantity: 10
-      - ReagentId: Oculine
-        Quantity: 2
   - type: FoodSequenceElement
     sprite:
       sprite: Objects/Specific/Hydroponics/carrot.rsi

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -351,8 +351,8 @@
   reactants:
     TableSalt:
       amount: 1
-    Blood:
-      amount: 1
+    JuiceCarrot:
+      amount: 2
     Hydroxide:
       amount: 2
   products:


### PR DESCRIPTION
This PR has two changes:

1.  _**Oculine removed from carrots.**_ Carrots have oculine in them, which makes them taste like medicine. But carrot juice metabolizes into oculine, so it doesn't really need to be there.
2.  _**Oculine recipe changed.**_ Oculine now needs carrot juice instead of blood. Increases botanical requirements for chem. Players might have to wait for the carrot anyway, bringing more players to botany to ask for carrots.